### PR TITLE
Fix errors when using upcoming scala 3.5.0

### DIFF
--- a/core/src/main/scala/pl/msitko/refined/compiletime/ValidateString.scala
+++ b/core/src/main/scala/pl/msitko/refined/compiletime/ValidateString.scala
@@ -20,12 +20,13 @@ object ValidateString:
           case _: false =>
             showPredicateV[E](constValue[V])
       case _: And[a, b] =>
-        // workaround for: https://github.com/lampepfl/dotty/issues/12715
-        inline val res = validate[V, a]
-        inline res match
-          case null =>
-            validate[V, b]
-          case _ => res
+        inline validate[V, a] match
+          case null => validate[V, b]
+          case _ => 
+            // inline vals cannot be null, so we cannot use that here for optimisation.
+            // In the future, this could be changed into
+            // `case res => res`, but the issue preventing this is not fixed on LTS yet.
+            validate[V, a]
       case _: Or[a, b] =>
         inline validate[V, a] match
           case null => null


### PR DESCRIPTION
This was picked up on scala 3's open-community-build: https://github.com/scala/scala3/issues/20292

Previously, a bug in the compiler could remove some parts of the code before an inline match. In this project, this prevented the exception `inline val with null is not supported` from appearing, since this check is done later in the compilation pipeline. Since that is fixed in 3.5.0, the exception can appear now.

Unfortunately, currently I do not have any better solution for this. `case res => res` (for now) only works in scala 3.4.0 and later, but it should be possible in the future.